### PR TITLE
fix: resolve all TypeScript type errors

### DIFF
--- a/src/tools/auggie-analysis.ts
+++ b/src/tools/auggie-analysis.ts
@@ -14,14 +14,13 @@
 
 import { APIError, Auggie, BlobTooLargeError } from '@augmentcode/auggie-sdk';
 import { SpanStatusCode } from '@opentelemetry/api';
-import type { AugmentCredentials } from '../config';
+import type { AugmentCredentials, Config } from '../config';
 import type { OwaspCategory, SecurityFinding } from '../graph/state';
 import { tracer } from '../instrumentation';
 import { withAgent } from '../observability';
 import { getOwaspPrompt } from './langfuse-prompts';
 import {
-    clearFindings,
-    reportVulnerabilityTool
+    clearFindings
 } from './report-vulnerability';
 
 /**

--- a/src/tools/direct-context-analysis.test.ts
+++ b/src/tools/direct-context-analysis.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { DirectContext as DirectContextType } from '@augmentcode/auggie-sdk';
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { DirectContextConfig } from './direct-context-analysis';
 
 // Create mock DirectContext instance
@@ -15,7 +15,6 @@ const mockDirectContext: Partial<DirectContextType> = {
   ) as DirectContextType['search'],
   getIndexedPaths: mock(() => ['src/index.ts', 'src/utils.ts']) as DirectContextType['getIndexedPaths'],
   exportToFile: mock(() => Promise.resolve()) as DirectContextType['exportToFile'],
-  close: mock(() => Promise.resolve()) as DirectContextType['close'],
 };
 
 // Mock the SDK module before importing the module under test
@@ -45,10 +44,10 @@ mock.module('@augmentcode/auggie-sdk', () => ({
 
 // Import module under test after mocking
 import {
-  createDirectContext,
-  exportContextState,
-  indexRepository,
-  searchForVulnerabilities,
+    createDirectContext,
+    exportContextState,
+    indexRepository,
+    searchForVulnerabilities,
 } from './direct-context-analysis';
 
 // Default test config - all tests must pass validated config
@@ -57,7 +56,6 @@ const defaultTestConfig: DirectContextConfig = {
     apiToken: 'test-token',
     apiUrl: 'https://test.api.com',
     sessionAuth: undefined,
-    apiKey: undefined,
   },
   nodeEnv: 'test',
 };
@@ -69,7 +67,6 @@ describe('DirectContext Analysis', () => {
     (mockDirectContext.search as ReturnType<typeof mock>).mockClear();
     (mockDirectContext.getIndexedPaths as ReturnType<typeof mock>).mockClear();
     (mockDirectContext.exportToFile as ReturnType<typeof mock>).mockClear();
-    (mockDirectContext.close as ReturnType<typeof mock>).mockClear();
     mockCreate.mockClear();
     mockImportFromFile.mockClear();
   });
@@ -106,7 +103,6 @@ describe('DirectContext Analysis', () => {
           apiToken: 'custom-token',
           apiUrl: 'https://custom.api.com',
           sessionAuth: undefined,
-          apiKey: undefined,
         },
         nodeEnv: 'test',
       };
@@ -125,13 +121,12 @@ describe('DirectContext Analysis', () => {
     test('parses sessionAuth JSON when provided in config', async () => {
       const config: DirectContextConfig = {
         augment: {
-          sessionAuth: JSON.stringify({
+          sessionAuth: {
             accessToken: 'session-token',
             tenantURL: 'https://tenant.api.com',
-          }),
+          },
           apiToken: undefined,
           apiUrl: undefined,
-          apiKey: undefined,
         },
         nodeEnv: 'development',
       };

--- a/src/tools/direct-context-analysis.ts
+++ b/src/tools/direct-context-analysis.ts
@@ -49,16 +49,12 @@ interface DirectContextCredentials {
 function getDirectContextCredentials(config: DirectContextConfig): DirectContextCredentials {
   const sessionAuth = config.augment?.sessionAuth;
   if (sessionAuth) {
-    try {
-      const parsed = JSON.parse(sessionAuth);
-      if (parsed.accessToken && parsed.tenantURL) {
-        return {
-          apiKey: parsed.accessToken,
-          apiUrl: parsed.tenantURL,
-        };
-      }
-    } catch {
-      console.warn('[direct-context] Failed to parse AUGMENT_SESSION_AUTH');
+    // sessionAuth is already parsed by Zod as an object
+    if (sessionAuth.accessToken && sessionAuth.tenantURL) {
+      return {
+        apiKey: sessionAuth.accessToken,
+        apiUrl: sessionAuth.tenantURL,
+      };
     }
   }
 


### PR DESCRIPTION
## Summary

This PR fixes all TypeScript type errors in the project, ensuring `bun run type-check` passes with zero errors.

## Changes

### 1. Fixed missing Config import (`src/tools/auggie-analysis.ts`)
- Added `Config` type to import statement from `'../config'`
- Required for `AuggieConfig` type definition

### 2. Removed invalid 'close' property (`src/tools/direct-context-analysis.test.ts`)
- DirectContext SDK type doesn't include a `close()` method
- Removed from mock object and beforeEach cleanup

### 3. Fixed invalid 'apiKey' property in test configs
- Augment config only supports `sessionAuth` OR `apiToken`/`apiUrl`
- Removed invalid `apiKey` property from test config objects

### 4. Fixed sessionAuth type mismatch
- Changed sessionAuth from JSON string to object in tests
- Zod schema already parses the JSON string from env vars, so Config type has it as an object

### 5. Updated sessionAuth parsing (`src/tools/direct-context-analysis.ts`)
- Removed `JSON.parse()` call in `getDirectContextCredentials()`
- sessionAuth is already parsed by Zod's `preprocess` function
- Added clarifying comment

## Verification

```bash
$ bun run type-check
$ tsc --noEmit
# ✅ No errors!
```

## Related

- Follows config schema defined in `src/config.ts`
- Aligns with Augment SDK v0.1.10 DirectContext type definitions
- Maintains compatibility with existing authentication flow

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author