### PR TITLE
Add Langfuse tool-level observations for Auggie and DirectContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,37 @@ bun run type-check # TypeScript validation
 ### Observability
 
 - **Full OpenTelemetry tracing** with Langfuse integration
-- **Semantic observation types**: retriever, agent, chain, tool
+- **Semantic observation types**: generation, retriever, agent, chain, tool
 - **Rich span attributes**: scan ID, repo path, OWASP category, severity, etc.
 - **Trace hierarchy**: Complete visibility into analysis workflow
+
+#### Tool-level observability in Langfuse
+
+GraphGuard wraps all tool-like operations using the `withTool()` helper in
+`src/observability/index.ts`, which creates Langfuse observations of type
+`tool`. These appear alongside agents, spans, and generations in the Langfuse
+UI and carry scan-aware metadata.
+
+**Key tool observation names:**
+
+| Observation name                    | Description                                               | Source file                               |
+|-------------------------------------|-----------------------------------------------------------|-------------------------------------------|
+| `tool.auggie_create`                | Auggie SDK client creation for a scan                     | `src/tools/auggie-analysis.ts`            |
+| `tool.auggie_prompt`                | Auggie SDK `client.prompt` OWASP analysis call           | `src/tools/auggie-analysis.ts`            |
+| `tool.direct_context_create`        | DirectContext creation or import from a saved state file  | `src/tools/direct-context-analysis.ts`    |
+| `tool.direct_context_index`         | DirectContext repository indexing                         | `src/tools/direct-context-analysis.ts`    |
+| `tool.direct_context_search`        | DirectContext semantic search for OWASP vulnerabilities   | `src/tools/direct-context-analysis.ts`    |
+| `tool.direct_context_export`        | Export DirectContext state to disk                        | `src/tools/direct-context-analysis.ts`    |
+| `tool.incremental_collect_metadata` | Collect filesystem metadata for incremental indexing      | `src/tools/incremental-indexer.ts`        |
+| `tool.incremental_analyze_changes`  | Detect new, changed, and deleted files                    | `src/tools/incremental-indexer.ts`        |
+| `tool.incremental_apply_update`     | Apply incremental file changes to DirectContext           | `src/tools/incremental-indexer.ts`        |
+| `tool.targeted_search`              | DirectContext search for OWASP-specific patterns          | `src/tools/targeted-search.ts`            |
+| `tool.targeted_search_and_analyze`  | Combined search + LLM analysis via DirectContext          | `src/tools/targeted-search.ts`            |
+| `tool.report_vulnerability`         | Structured vulnerability reporting tool used by Auggie    | `src/tools/report-vulnerability.ts`       |
+
+In a typical scan, you will see `tool.auggie_create` and `tool.auggie_prompt`
+nested under the OWASP analysis agent for each category, along with
+DirectContext and incremental indexing tools when those paths are enabled.
 
 ### Security Analysis
 

--- a/src/tools/auggie-analysis.ts
+++ b/src/tools/auggie-analysis.ts
@@ -17,7 +17,7 @@ import { SpanStatusCode } from '@opentelemetry/api';
 import type { AugmentCredentials, Config } from '../config';
 import type { OwaspCategory, SecurityFinding } from '../graph/state';
 import { tracer } from '../instrumentation';
-import { withAgent } from '../observability';
+import { withAgent, withTool } from '../observability';
 import { getOwaspPrompt } from './langfuse-prompts';
 import {
     clearFindings
@@ -161,17 +161,36 @@ export async function analyzeWithAuggie(
               `[auggie] Analyzing ${repoPath} for ${category} with ${model}`
             );
 
-            // Initialize Auggie with the repository and credentials
-            client = await Auggie.create({
-              workspaceRoot: repoPath,
-              model,
-              // Pass credentials from validated config
-              apiKey: credentials.apiKey,
-              apiUrl: credentials.apiUrl,
-              // tools: {
-              //   report_vulnerability: reportVulnerabilityTool,
-              // },
-            });
+	            // Initialize Auggie with the repository and credentials
+	            client = await withTool(
+	              'tool.auggie_create',
+	              async () =>
+	                Auggie.create({
+	                  workspaceRoot: repoPath,
+	                  model,
+	                  // Pass credentials from validated config
+	                  apiKey: credentials.apiKey,
+	                  apiUrl: credentials.apiUrl,
+	                  // tools: {
+	                  //   report_vulnerability: reportVulnerabilityTool,
+	                  // },
+	                }),
+	              {
+	                input: {
+	                  repoPath,
+	                  model,
+	                },
+	                scanContext: {
+	                  scanId,
+	                  owaspCategory: category,
+	                  repoPath,
+	                },
+	                metadata: {
+	                  toolName: 'auggie_create',
+	                  toolType: 'auggie_sdk',
+	                },
+	              }
+	            );
 
             // Build the analysis prompt - ask for structured JSON output
             const analysisPrompt = `${prompt.text}
@@ -197,8 +216,28 @@ For EACH vulnerability you find, include it in a JSON array with this structure:
 Be thorough but precise. Only report actual vulnerabilities with evidence.
 Return ONLY the JSON array, no other text.`;
 
-            // Let Auggie orchestrate the analysis
-            const response = await client.prompt(analysisPrompt);
+	            // Let Auggie orchestrate the analysis via a tool observation
+	            const response = await withTool(
+	              'tool.auggie_prompt',
+	              async () => client!.prompt(analysisPrompt),
+	              {
+	                input: {
+	                  category,
+	                  model,
+	                  // Avoid sending the full prompt body in metadata
+	                  promptPreview: analysisPrompt.slice(0, 500),
+	                },
+	                scanContext: {
+	                  scanId,
+	                  owaspCategory: category,
+	                  repoPath,
+	                },
+	                metadata: {
+	                  toolName: 'auggie_prompt',
+	                  toolType: 'auggie_sdk',
+	                },
+	              }
+	            );
 
             console.log(`[auggie] Analysis complete. Response length: ${response.length}`);
 

--- a/src/tools/direct-context-analysis.ts
+++ b/src/tools/direct-context-analysis.ts
@@ -122,48 +122,64 @@ export async function createDirectContext(
   config: DirectContextConfig,
   stateFilePath?: string
 ): Promise<DirectContext> {
-  return tracer.startActiveSpan('direct_context.create', async (span) => {
-    try {
-      const credentials = getDirectContextCredentials(config);
-      const isDebug = config.nodeEnv === 'development';
-      let context: DirectContext;
+	  return withTool(
+	    'tool.direct_context_create',
+	    async () =>
+	      tracer.startActiveSpan('direct_context.create', async (span) => {
+	        try {
+	          const credentials = getDirectContextCredentials(config);
+	          const isDebug = config.nodeEnv === 'development';
+	          let context: DirectContext;
 
-      if (stateFilePath) {
-        console.log(`[direct-context] Importing state from ${stateFilePath}`);
-        span.setAttribute('state.import', true);
-        span.setAttribute('state.file', stateFilePath);
+	          if (stateFilePath) {
+	            console.log(`[direct-context] Importing state from ${stateFilePath}`);
+	            span.setAttribute('state.import', true);
+	            span.setAttribute('state.file', stateFilePath);
 
-        context = await DirectContext.importFromFile(stateFilePath, {
-          ...credentials,
-          debug: isDebug,
-        });
+	            context = await DirectContext.importFromFile(stateFilePath, {
+	              ...credentials,
+	              debug: isDebug,
+	            });
 
-        const indexedPaths = context.getIndexedPaths();
-        console.log(`[direct-context] Restored ${indexedPaths.length} indexed files`);
-        span.setAttribute('state.indexed_files', indexedPaths.length);
-      } else {
-        console.log('[direct-context] Creating new context');
-        span.setAttribute('state.import', false);
+	            const indexedPaths = context.getIndexedPaths();
+	            console.log(
+	              `[direct-context] Restored ${indexedPaths.length} indexed files`
+	            );
+	            span.setAttribute('state.indexed_files', indexedPaths.length);
+	          } else {
+	            console.log('[direct-context] Creating new context');
+	            span.setAttribute('state.import', false);
 
-        context = await DirectContext.create({
-          ...credentials,
-          debug: isDebug,
-        });
-      }
+	            context = await DirectContext.create({
+	              ...credentials,
+	              debug: isDebug,
+	            });
+	          }
 
-      span.setStatus({ code: SpanStatusCode.OK });
-      return context;
-    } catch (error) {
-      span.setStatus({
-        code: SpanStatusCode.ERROR,
-        message: error instanceof Error ? error.message : String(error),
-      });
-      span.recordException(error as Error);
-      throw error;
-    } finally {
-      span.end();
-    }
-  });
+	          span.setStatus({ code: SpanStatusCode.OK });
+	          return context;
+	        } catch (error) {
+	          span.setStatus({
+	            code: SpanStatusCode.ERROR,
+	            message: error instanceof Error ? error.message : String(error),
+	          });
+	          span.recordException(error as Error);
+	          throw error;
+	        } finally {
+	          span.end();
+	        }
+	      }),
+	    {
+	      input: {
+	        hasStateFile: Boolean(stateFilePath),
+	        stateFilePath,
+	      },
+	      metadata: {
+	        toolName: 'direct_context_create',
+	        operation: stateFilePath ? 'import_from_file' : 'create',
+	      },
+	    }
+	  );
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR enhances Langfuse observability by adding explicit **tool-level observations** for Auggie SDK calls and DirectContext operations, and documents them in the README.

## Changes

### 1. Tool observations for Auggie SDK

**File:** `src/tools/auggie-analysis.ts`

- Wrap `Auggie.create()` in a `withTool()` observation:
  - Observation name: `tool.auggie_create`
  - Metadata includes `scanId`, `owaspCategory`, and `repoPath`.
- Wrap `client.prompt()` (OWASP analysis) in a `withTool()` observation:
  - Observation name: `tool.auggie_prompt`
  - Metadata includes `scanId`, `owaspCategory`, `repoPath`, and a `promptPreview` (first 500 chars instead of the full prompt body for safety).
- These tool observations are nested under the existing agent/span structure (`withAgent` + `tracer.startActiveSpan('auggie.analyze.*')`), so they appear in Langfuse as children of the OWASP analysis node.

### 2. Tool observations for DirectContext creation/import

**File:** `src/tools/direct-context-analysis.ts`

- Wrap `createDirectContext()` in `withTool()` so DirectContext lifecycle is visible as a Langfuse **tool** observation:
  - Observation name: `tool.direct_context_create`
  - Captures whether we are **creating** a new context or **importing from file** via `metadata.operation`.
  - Still uses `tracer.startActiveSpan('direct_context.create')` inside for OTel span-level details; the span is nested under the tool observation.

### 3. README documentation for tool-level observability

**File:** `README.md`

- Extend the **Observability** section to:
  - Explicitly mention `generation` in the list of semantic observation types.
  - Add a new subsection: **"Tool-level observability in Langfuse"**.
- Document the key tool observation names and their source files in a table:
  - `tool.auggie_create` – Auggie SDK client creation
  - `tool.auggie_prompt` – Auggie OWASP analysis prompt
  - `tool.direct_context_create` – DirectContext create/import
  - `tool.direct_context_index` – DirectContext repository indexing
  - `tool.direct_context_search` – DirectContext semantic search
  - `tool.direct_context_export` – DirectContext state export
  - `tool.incremental_collect_metadata` – Filesystem metadata collection
  - `tool.incremental_analyze_changes` – Change detection (new/changed/deleted files)
  - `tool.incremental_apply_update` – Apply incremental updates to DirectContext
  - `tool.targeted_search` – Targeted OWASP search via DirectContext
  - `tool.targeted_search_and_analyze` – Combined search + analysis
  - `tool.report_vulnerability` – Structured vulnerability reporting tool used by Auggie
- Describe how these appear in Langfuse during a typical scan (nested under the OWASP analysis agent, alongside existing spans and generations).

## Motivation

Previously, Auggie SDK calls and DirectContext creation were only visible as generic spans/agents, which made it harder to:

- Answer questions like "what tools did this scan actually call?"
- Debug Auggie/DirectContext behavior from Langfuse alone.
- Correlate specific vulnerabilities to the underlying tool invocations.

By standardizing on `withTool()` for these operations and documenting the resulting observation names, we get:

- Consistent, queryable tool-level traces in Langfuse.
- Clear separation between **agent** orchestration, **generation** (LLM calls), and **tool** invocations.
- Better auditability for how scans interact with Auggie and the Augment SDK.

## Testing

- Ran unit tests:

  ```bash
  bun test src/
  ```

- All tests passed (including observability, DirectContext, incremental indexer, and targeted search tests).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author